### PR TITLE
SEC-3190: Updated gemfile to use Chime gem proxy instead of rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source "https://gem-proxy.chime.com"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       sidekiq-cron (= 1.1.0)
 
 GEM
-  remote: https://rubygems.org/
+  remote: https://gem-proxy.chime.com/
   specs:
     concurrent-ruby (1.1.5)
     connection_pool (2.2.2)


### PR DESCRIPTION
### JIRA: https://chime.atlassian.net/browse/SEC-3190