### PR TITLE
build: switch to `base-ruby` base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ruby:2.3.3
+FROM chimebank/base-ruby:main-2.5
+
 RUN cd /tmp && curl -L --output ghr.tar.gz https://github.com/tcnksm/ghr/releases/download/v0.12.0/ghr_v0.12.0_linux_amd64.tar.gz && \
     tar -xzvf ghr.tar.gz && chmod +x ghr_v0.12.0_linux_amd64/ghr && mv ghr_v0.12.0_linux_amd64/ghr /usr/local/bin/ghr && rm -rf /tmp/*
 


### PR DESCRIPTION
This PR migrates your Dockerfile from the publicly available `ruby` image to Chime's internal and approved `base-ruby` image. This makes sure that all the tooling is available and continuously updated. Applying this change will also bump [your Monocle score](https://monocle.chime.com/).

As a follow up, it is also recommended that you consider upgrading your Ruby version to Ruby `2.7` or even better `3.0` when/if possible as there will be no further releases from the `2.5` series. Check out the [base-ruby images README](https://github.com/1debit/base-images/tree/main/base-ruby#current-images) for more details about available base-ruby image versions.

We're going to keep track of this update via https://github.com/1debit/security-monocle/issues/330