### PR TITLE
Upgrade to Github-native Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,8 @@ updates:
   - package-ecosystem: bundler
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
+      day: tuesday
       time: "09:00" # UTC
     pull-request-branch-name:
       separator: "-"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+registries:
+  rubygems-server-gem-fury-io-chime:
+    type: rubygems-server
+    url: https://gem.fury.io/chime
+    token: "${{secrets.RUBYGEMS_SERVER_GEM_FURY_IO_CHIME_TOKEN}}"
+  github-octocat:
+    type: git
+    url: https://github.com
+    username: x-access-token
+    password: "${{secrets.RUBYGEMS_SERVER_GITHUB_TOKEN}}"
+
+updates:
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "09:00" # UTC
+    pull-request-branch-name:
+      separator: "-"
+    commit-message:
+      prefix: "chore "
+      prefix-development: "chore "
+      include: scope
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10
+    versioning-strategy: lockfile-only
+    registries:
+      - rubygems-server-gem-fury-io-chime
+      - github-octocat


### PR DESCRIPTION
_Dependabot Preview will be shut down on August 3rd, 2021. In order to keep getting Dependabot updates, please merge this PR and migrate to GitHub-native Dependabot before then._

Dependabot has been fully integrated into GitHub, so you no longer have to install and manage a separate app. This pull request migrates your configuration from Dependabot.com to a config file, using the [new syntax][new_syntax]. When merged, we'll swap out `dependabot-preview` (me) for a new `dependabot` app, and you'll be all set!

With this change, you'll now use the [Dependabot page in GitHub][dependabot_page], rather than the [Dependabot dashboard][dashboard], to monitor your version updates, and you'll configure Dependabot through the new config file rather than a UI.




Your account is using config variables to access private registries. Relevant registries have been included in the new config file but additional steps may be necessary to complete the setup.
Ensure that each secret below has been configured in the [organization Dependabot secrets][org_secrets_url] or the [repository Dependabot secrets][repo_secrets_url] by an admin.

- [ ] RUBYGEMS_SERVER_GEM_FURY_IO_CHIME_TOKEN
- [ ] RUBYGEMS_SERVER_GITHUB_TOKEN

If an included registry is not required by this repository you can remove it from the config file.



If you've got any questions or feedback for us, please let us know by creating an issue in the [dependabot/dependabot-core][issues] repository.

[Learn more about migrating to GitHub-native Dependabot][learn]

Please note that regular `@dependabot` commands do not work on this pull request.

[dashboard]: https://app.dependabot.com/
[dependabot_page]: https://github.com/1debit/chime-service-base/network/updates
[issues]: https://github.com/dependabot/dependabot-core/issues/new?assignees=%40dependabot%2Fpreview-migration-reviewers&labels=E%3A+preview-migration&template=migration-issue.md
[learn]: http://docs.github.com/code-security/supply-chain-security/upgrading-from-dependabotcom-to-github-native-dependabot
[new_syntax]: https://help.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
[org_secrets_url]: https://github.com/organizations/1debit/settings/secrets/dependabot
[repo_secrets_url]: https://github.com/1debit/chime-service-base/settings/secrets/dependabot
