### PR TITLE
ruby 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 
 defaults: &defaults
   docker:
-    - image: circleci/ruby:2.5
+    - image: circleci/ruby:2.7
 
 jobs:
   test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-FROM chimebank/base-ruby:main-2.5
-
-RUN cd /tmp && curl -L --output ghr.tar.gz https://github.com/tcnksm/ghr/releases/download/v0.12.0/ghr_v0.12.0_linux_amd64.tar.gz && \
-    tar -xzvf ghr.tar.gz && chmod +x ghr_v0.12.0_linux_amd64/ghr && mv ghr_v0.12.0_linux_amd64/ghr /usr/local/bin/ghr && rm -rf /tmp/*
+ARG DOCKER_PREFIX=chimebank
+FROM $DOCKER_PREFIX/base-ruby:main-2.7
 
 WORKDIR /gem
 COPY Gemfile /gem/Gemfile

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,38 +7,33 @@ PATH
 GEM
   remote: https://gem-proxy.chime.com/
   specs:
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     connection_pool (2.2.5)
-    et-orbi (1.2.4)
+    et-orbi (1.2.5)
       tzinfo
-    fugit (1.4.5)
+    fugit (1.5.2)
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.4)
-    metaclass (0.0.4)
-    minitest (5.12.2)
-    mocha (1.9.0)
-      metaclass (~> 0.0.1)
-    power_assert (1.1.5)
+    minitest (5.14.4)
+    mocha (1.13.0)
+    power_assert (2.0.1)
     raabro (1.4.0)
     rack (2.2.3)
-    rack-protection (2.1.0)
-      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rake (13.0.1)
-    redis (4.1.3)
-    redis-namespace (1.6.0)
+    rake (13.0.6)
+    redis (4.4.0)
+    redis-namespace (1.8.1)
       redis (>= 3.0.4)
-    shoulda-context (1.2.2)
-    sidekiq (6.0.7)
+    shoulda-context (2.0.0)
+    sidekiq (6.2.2)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
-      rack-protection (>= 2.0.0)
-      redis (>= 4.1.0)
+      redis (>= 4.2.0)
     sidekiq-cron (1.1.0)
       fugit (~> 1.1)
       sidekiq (>= 4.2.1)
-    test-unit (3.3.4)
+    test-unit (3.4.7)
       power_assert
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -47,7 +42,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.17)
+  bundler (~> 2.2)
   minitest
   mocha
   rack
@@ -59,4 +54,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   1.17.3
+   2.2.25

--- a/sidekiq-cron-web-admin.gemspec
+++ b/sidekiq-cron-web-admin.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'sidekiq-cron', '1.1.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.17'
+  spec.add_development_dependency 'bundler', '~> 2.2'
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'mocha'
   spec.add_development_dependency 'rack'


### PR DESCRIPTION
ruby 2.5 is no longer supported so Chime is in the process of upgrading all repos / services to 2.7 (and perhaps one day ruby 3)