### PR TITLE
Rename ci-tools to cit [DX-916]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  cit: chime/ci-tools@1
+  cit: chime/cit@1
 
 defaults: &defaults
   docker:


### PR DESCRIPTION
ci-tools has been renamed to cit while securing it.

[_Created by Sourcegraph batch change `kylev/ci-tools-rename`._](https://chime.sourcegraph.com/users/kylev/batch-changes/ci-tools-rename)