### PR TITLE
DO NOT SUBMIT Test migrate default image from circleci to cimg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  cit: chime/cit@1
+  cit: chime/cit@dev:migrate_image
 
 defaults: &defaults
   docker:


### PR DESCRIPTION
Checking to see what would break if the default image for unit tests was cimg instead of the deprecated circleci image. This PR should not be submitted is just used to determine if there will be problems.

[_Created by Sourcegraph batch change `JohnVincentFinn/MigrateCircleciImage`._](https://chime.sourcegraph.com/users/JohnVincentFinn/batch-changes/MigrateCircleciImage)