### PR TITLE
[CI-41] Replace legacy circleci/ images with cimg/

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 
 defaults: &defaults
   docker:
-    - image: circleci/ruby:2.7
+    - image: cimg/ruby:2.7
 
 jobs:
   test:


### PR DESCRIPTION
We have changed the default images in https://github.com/1debit/ci-tools/pull/741 from the deprecated "circleci/" to the new generation of "cimg/" convenience CircleCI images.

We are now also replacing all usage of the legacy "circleci/" images in individual repositories as well to make sure that they are not used anymore at all. Note that the deprecated images have not received any updates for almost a year now (Dec 31 2021).

If you are interested in more details, please check the [CircleCI documentation about the legacy convenience image deprecations](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034).

Should you have any further questions, please comment on the PR or come ask us in #eng-ci-ask

[_Created by Sourcegraph batch change `maciej-chime/ReplaceCircleciWithCimgImages`._](https://chime.sourcegraph.com/users/maciej-chime/batch-changes/ReplaceCircleciWithCimgImages)